### PR TITLE
fix(tsf): avoid crash/hang on IME input in affected apps

### DIFF
--- a/crates/client/src/tsf/edit_session.rs
+++ b/crates/client/src/tsf/edit_session.rs
@@ -12,7 +12,12 @@ use windows::{
     },
 };
 
-use std::{cell::Cell, mem::ManuallyDrop, rc::Rc};
+use std::{
+    cell::Cell,
+    mem::ManuallyDrop,
+    rc::Rc,
+    time::{Duration, Instant},
+};
 
 use anyhow::{Context, Result};
 
@@ -275,12 +280,24 @@ impl TextServiceFactory {
     #[tracing::instrument]
     pub fn update_pos(&self) -> Result<()> {
         {
-            let mut text_service = self.borrow_mut()?;
+            let mut text_service = match self.borrow_mut() {
+                Ok(text_service) => text_service,
+                Err(error) => {
+                    tracing::warn!("Skip update_pos due to borrow conflict: {error:?}");
+                    return Ok(());
+                }
+            };
+
             if text_service.is_updating_pos {
                 tracing::debug!("Skip re-entrant update_pos call");
                 return Ok(());
             }
+
             text_service.is_updating_pos = true;
+            // GetTextExt can trigger a layout-change callback in some apps (e.g. Mery).
+            // Suppress the immediate callback to avoid feedback loops.
+            text_service.suppress_layout_change_until =
+                Some(Instant::now() + Duration::from_millis(200));
         }
 
         let result: Result<()> = (|| {

--- a/crates/client/src/tsf/edit_session.rs
+++ b/crates/client/src/tsf/edit_session.rs
@@ -274,41 +274,47 @@ impl TextServiceFactory {
 
     #[tracing::instrument]
     pub fn update_pos(&self) -> Result<()> {
-        let text_service = self.borrow()?;
-        let composition = text_service.borrow_composition()?;
+        let result: Result<()> = (|| {
+            let text_service = self.borrow()?;
+            let composition = text_service.borrow_composition()?;
 
-        if let Some(tip_composition) = composition.tip_composition.clone() {
-            edit_session(
-                text_service.tid,
-                text_service.context()?,
-                Rc::new({
-                    let context = text_service.context::<ITfContext>()?;
+            if let Some(tip_composition) = composition.tip_composition.clone() {
+                edit_session(
+                    text_service.tid,
+                    text_service.context()?,
+                    Rc::new({
+                        let context = text_service.context::<ITfContext>()?;
 
-                    move |cookie| unsafe {
-                        let view = context.GetActiveView()?;
-                        let range = tip_composition.GetRange()?;
-                        let mut ipc_service = IMEState::get()?
-                            .ipc_service
-                            .clone()
-                            .context("ipc_service is None")?;
+                        move |cookie| unsafe {
+                            let view = context.GetActiveView()?;
+                            let range = tip_composition.GetRange()?;
 
-                        let mut rect = RECT::default();
-                        let mut clipped = false.into();
-                        view.GetTextExt(cookie, &range, &mut rect, &mut clipped)?;
+                            let Some(mut ipc_service) = IMEState::get()?.ipc_service.clone() else {
+                                return Ok(());
+                            };
 
-                        ipc_service.set_window_position(
-                            rect.top,
-                            rect.left,
-                            rect.bottom,
-                            rect.right,
-                        )?;
+                            let mut rect = RECT::default();
+                            let mut clipped = false.into();
+                            view.GetTextExt(cookie, &range, &mut rect, &mut clipped)?;
 
-                        Ok(())
-                    }
-                }),
-            )?;
+                            ipc_service.set_window_position(
+                                rect.top,
+                                rect.left,
+                                rect.bottom,
+                                rect.right,
+                            )?;
 
-            return Ok(());
+                            Ok(())
+                        }
+                    }),
+                )?;
+            }
+
+            Ok(())
+        })();
+
+        if let Err(error) = result {
+            tracing::warn!("Failed to update composition window position: {error:?}");
         }
 
         Ok(())

--- a/crates/client/src/tsf/edit_session.rs
+++ b/crates/client/src/tsf/edit_session.rs
@@ -274,16 +274,32 @@ impl TextServiceFactory {
 
     #[tracing::instrument]
     pub fn update_pos(&self) -> Result<()> {
-        let result: Result<()> = (|| {
-            let text_service = self.borrow()?;
-            let composition = text_service.borrow_composition()?;
+        {
+            let mut text_service = self.borrow_mut()?;
+            if text_service.is_updating_pos {
+                tracing::debug!("Skip re-entrant update_pos call");
+                return Ok(());
+            }
+            text_service.is_updating_pos = true;
+        }
 
-            if let Some(tip_composition) = composition.tip_composition.clone() {
-                edit_session(
+        let result: Result<()> = (|| {
+            let (tid, context, tip_composition) = {
+                let text_service = self.borrow()?;
+                let composition = text_service.borrow_composition()?;
+                (
                     text_service.tid,
-                    text_service.context()?,
+                    text_service.context::<ITfContext>()?,
+                    composition.tip_composition.clone(),
+                )
+            };
+
+            if let Some(tip_composition) = tip_composition {
+                edit_session(
+                    tid,
+                    context.clone(),
                     Rc::new({
-                        let context = text_service.context::<ITfContext>()?;
+                        let context = context.clone();
 
                         move |cookie| unsafe {
                             let view = context.GetActiveView()?;
@@ -312,6 +328,15 @@ impl TextServiceFactory {
 
             Ok(())
         })();
+
+        match self.borrow_mut() {
+            Ok(mut text_service) => {
+                text_service.is_updating_pos = false;
+            }
+            Err(error) => {
+                tracing::warn!("Failed to reset update_pos guard: {error:?}");
+            }
+        }
 
         if let Err(error) = result {
             tracing::warn!("Failed to update composition window position: {error:?}");

--- a/crates/client/src/tsf/edit_session.rs
+++ b/crates/client/src/tsf/edit_session.rs
@@ -12,12 +12,7 @@ use windows::{
     },
 };
 
-use std::{
-    cell::Cell,
-    mem::ManuallyDrop,
-    rc::Rc,
-    time::{Duration, Instant},
-};
+use std::{cell::Cell, mem::ManuallyDrop, rc::Rc, time::Instant};
 
 use anyhow::{Context, Result};
 
@@ -288,16 +283,13 @@ impl TextServiceFactory {
                 }
             };
 
-            if text_service.is_updating_pos {
+            if !text_service
+                .update_pos_state
+                .try_begin_update(Instant::now())
+            {
                 tracing::debug!("Skip re-entrant update_pos call");
                 return Ok(());
             }
-
-            text_service.is_updating_pos = true;
-            // GetTextExt can trigger a layout-change callback in some apps (e.g. Mery).
-            // Suppress the immediate callback to avoid feedback loops.
-            text_service.suppress_layout_change_until =
-                Some(Instant::now() + Duration::from_millis(200));
         }
 
         let result: Result<()> = (|| {
@@ -348,7 +340,7 @@ impl TextServiceFactory {
 
         match self.borrow_mut() {
             Ok(mut text_service) => {
-                text_service.is_updating_pos = false;
+                text_service.update_pos_state.finish_update(Instant::now());
             }
             Err(error) => {
                 tracing::warn!("Failed to reset update_pos guard: {error:?}");

--- a/crates/client/src/tsf/surrounded_text.rs
+++ b/crates/client/src/tsf/surrounded_text.rs
@@ -65,16 +65,12 @@ impl TextServiceFactory {
                 Err(_) => return Ok(document_manager),
             };
 
-            // Check if variant is VT_UNKNOWN and not null
-            if variant.as_raw().Anonymous.Anonymous.vt != 13u16 || // VT_UNKNOWN = 13
-               variant.as_raw().Anonymous.Anonymous.Anonymous.punkVal.is_null()
-            {
-                return Ok(document_manager);
-            }
-
-            // Get parent document manager
-            let variant_punk = variant.as_raw().Anonymous.Anonymous.Anonymous.punkVal;
-            let variant_unk: IUnknown = std::mem::transmute(variant_punk);
+            // Use a cloned IUnknown from VARIANT to avoid invalid reference-count handling.
+            // If this is not VT_UNKNOWN (or null), treat it as "parent not available".
+            let variant_unk = match IUnknown::try_from(&variant) {
+                Ok(unk) => unk,
+                Err(_) => return Ok(document_manager),
+            };
 
             match variant_unk.cast::<ITfDocumentMgr>() {
                 Ok(parent_doc_mgr) => Ok(parent_doc_mgr),

--- a/crates/client/src/tsf/surrounded_text.rs
+++ b/crates/client/src/tsf/surrounded_text.rs
@@ -3,7 +3,7 @@
 
 use std::{mem::ManuallyDrop, rc::Rc};
 
-use anyhow::{Context as _, Result};
+use anyhow::Result;
 use windows::{
     core::{IUnknown, Interface},
     Win32::UI::TextServices::{
@@ -106,7 +106,7 @@ impl TextServiceFactory {
     }
 
     pub fn update_context(&self, preview: &str) -> Result<()> {
-        unsafe {
+        let result: Result<()> = (|| unsafe {
             let text_service = self.borrow()?;
 
             let context = text_service.context::<ITfContext>()?;
@@ -129,8 +129,14 @@ impl TextServiceFactory {
                             &mut pfetched,
                         )?;
 
-                        let prange = &pselection[0].range;
-                        let range = prange.as_ref().context("Range not found")?.Clone()?;
+                        if pfetched == 0 {
+                            return Ok(String::new());
+                        }
+
+                        let range = match pselection[0].range.as_ref() {
+                            Some(range) => range.Clone()?,
+                            None => return Ok(String::new()),
+                        };
 
                         let mut preceding_range_shifted = 0;
 
@@ -170,14 +176,23 @@ impl TextServiceFactory {
                 }),
             )?;
 
-            let mut ipc_service = IMEState::get()?
-                .ipc_service
-                .clone()
-                .context("ipc_service is None")?;
+            let Some(preceding_text) = preceding_text else {
+                return Ok(());
+            };
 
-            ipc_service.set_context(preceding_text.context("preceding_text is null")?)?;
+            let Some(mut ipc_service) = IMEState::get()?.ipc_service.clone() else {
+                return Ok(());
+            };
+
+            ipc_service.set_context(preceding_text)?;
 
             Ok(())
+        })();
+
+        if let Err(error) = result {
+            tracing::warn!("Failed to update surrounded text context: {error:?}");
         }
+
+        Ok(())
     }
 }

--- a/crates/client/src/tsf/text_layout_sink.rs
+++ b/crates/client/src/tsf/text_layout_sink.rs
@@ -24,10 +24,15 @@ impl ITfTextLayoutSink_Impl for TextServiceFactory_Impl {
         _lcode: TfLayoutCode,
         _pview: Option<&ITfContextView>,
     ) -> Result<()> {
+        let now = Instant::now();
         let should_skip = match self.borrow_mut() {
-            Ok(mut text_service) => match text_service.suppress_layout_change_until.take() {
-                Some(until) if Instant::now() <= until => true,
-                Some(_) | None => false,
+            Ok(mut text_service) => match text_service.suppress_layout_change_until {
+                Some(until) if now <= until => true,
+                Some(_) => {
+                    text_service.suppress_layout_change_until = None;
+                    false
+                }
+                None => false,
             },
             Err(error) => {
                 tracing::warn!("Skip OnLayoutChange due to borrow conflict: {error:?}");

--- a/crates/client/src/tsf/text_layout_sink.rs
+++ b/crates/client/src/tsf/text_layout_sink.rs
@@ -1,3 +1,5 @@
+use std::time::Instant;
+
 use windows::{
     core::Interface as _,
     Win32::UI::TextServices::{
@@ -22,7 +24,25 @@ impl ITfTextLayoutSink_Impl for TextServiceFactory_Impl {
         _lcode: TfLayoutCode,
         _pview: Option<&ITfContextView>,
     ) -> Result<()> {
-        self.update_pos()?;
+        let should_skip = match self.borrow_mut() {
+            Ok(mut text_service) => match text_service.suppress_layout_change_until.take() {
+                Some(until) if Instant::now() <= until => true,
+                Some(_) | None => false,
+            },
+            Err(error) => {
+                tracing::warn!("Skip OnLayoutChange due to borrow conflict: {error:?}");
+                true
+            }
+        };
+
+        if should_skip {
+            tracing::debug!("Skip layout-triggered update_pos to avoid feedback loop");
+            return Ok(());
+        }
+
+        if let Err(error) = self.update_pos() {
+            tracing::warn!("Failed to update position from OnLayoutChange: {error:?}");
+        }
 
         Ok(())
     }

--- a/crates/client/src/tsf/text_layout_sink.rs
+++ b/crates/client/src/tsf/text_layout_sink.rs
@@ -1,5 +1,3 @@
-use std::time::Instant;
-
 use windows::{
     core::Interface as _,
     Win32::UI::TextServices::{
@@ -24,16 +22,10 @@ impl ITfTextLayoutSink_Impl for TextServiceFactory_Impl {
         _lcode: TfLayoutCode,
         _pview: Option<&ITfContextView>,
     ) -> Result<()> {
-        let now = Instant::now();
         let should_skip = match self.borrow_mut() {
-            Ok(mut text_service) => match text_service.suppress_layout_change_until {
-                Some(until) if now <= until => true,
-                Some(_) => {
-                    text_service.suppress_layout_change_until = None;
-                    false
-                }
-                None => false,
-            },
+            Ok(mut text_service) => text_service
+                .update_pos_state
+                .should_skip_layout_change(std::time::Instant::now()),
             Err(error) => {
                 tracing::warn!("Skip OnLayoutChange due to borrow conflict: {error:?}");
                 true

--- a/crates/client/src/tsf/text_service.rs
+++ b/crates/client/src/tsf/text_service.rs
@@ -18,6 +18,7 @@ pub struct TextService {
     pub thread_mgr: Option<ITfThreadMgr>,
     pub context: Option<ITfContext>,
     pub composition: RefCell<Composition>,
+    pub is_updating_pos: bool,
     pub display_attribute_atom: HashMap<GUID, u32>,
     pub mode: InputMode,
     pub this: Option<ITfTextInputProcessor>,

--- a/crates/client/src/tsf/text_service.rs
+++ b/crates/client/src/tsf/text_service.rs
@@ -1,7 +1,7 @@
 use std::{
     cell::{Ref, RefCell, RefMut},
     collections::HashMap,
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use windows::{
@@ -13,14 +13,65 @@ use anyhow::{Context, Result};
 
 use crate::engine::{composition::Composition, input_mode::InputMode};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum UpdatePosState {
+    #[default]
+    Idle,
+    Updating {
+        suppress_layout_until: Instant,
+    },
+    SuppressingLayoutChange {
+        until: Instant,
+    },
+}
+
+impl UpdatePosState {
+    const LAYOUT_CHANGE_SUPPRESSION: Duration = Duration::from_millis(200);
+
+    pub fn try_begin_update(&mut self, now: Instant) -> bool {
+        if matches!(self, Self::Updating { .. }) {
+            return false;
+        }
+
+        *self = Self::Updating {
+            suppress_layout_until: now + Self::LAYOUT_CHANGE_SUPPRESSION,
+        };
+
+        true
+    }
+
+    pub fn finish_update(&mut self, now: Instant) {
+        *self = match *self {
+            Self::Updating {
+                suppress_layout_until,
+            } if now <= suppress_layout_until => Self::SuppressingLayoutChange {
+                until: suppress_layout_until,
+            },
+            Self::Updating { .. } => Self::Idle,
+            state => state,
+        };
+    }
+
+    pub fn should_skip_layout_change(&mut self, now: Instant) -> bool {
+        match *self {
+            Self::Idle => false,
+            Self::Updating { .. } => true,
+            Self::SuppressingLayoutChange { until } if now <= until => true,
+            Self::SuppressingLayoutChange { .. } => {
+                *self = Self::Idle;
+                false
+            }
+        }
+    }
+}
+
 #[derive(Default, Debug)]
 pub struct TextService {
     pub tid: u32,
     pub thread_mgr: Option<ITfThreadMgr>,
     pub context: Option<ITfContext>,
     pub composition: RefCell<Composition>,
-    pub is_updating_pos: bool,
-    pub suppress_layout_change_until: Option<Instant>,
+    pub update_pos_state: UpdatePosState,
     pub display_attribute_atom: HashMap<GUID, u32>,
     pub mode: InputMode,
     pub this: Option<ITfTextInputProcessor>,

--- a/crates/client/src/tsf/text_service.rs
+++ b/crates/client/src/tsf/text_service.rs
@@ -1,6 +1,7 @@
 use std::{
     cell::{Ref, RefCell, RefMut},
     collections::HashMap,
+    time::Instant,
 };
 
 use windows::{
@@ -19,6 +20,7 @@ pub struct TextService {
     pub context: Option<ITfContext>,
     pub composition: RefCell<Composition>,
     pub is_updating_pos: bool,
+    pub suppress_layout_change_until: Option<Instant>,
     pub display_attribute_atom: HashMap<GUID, u32>,
     pub mode: InputMode,
     pub this: Option<ITfTextInputProcessor>,


### PR DESCRIPTION
## Summary
Issue #36 で報告された、特定アプリでIME入力時にクラッシュ/ハングする問題を修正します。

- unsafe COM 変換を安全化
- `update_pos` の再入ループを抑止
- 位置更新失敗時の処理を fail-open 化して入力継続性を改善
- `OnLayoutChange` 通知が短時間に複数回来ても抑止期間が維持されるよう修正

## Background
Issue #36 では、複数アプリでIME入力時の不安定化が報告されていました。

特に Mery で、IME ON 状態で文字入力開始時にクラッシュ/ハングが再発していました。
ダンプ解析の結果、`GetTextExt -> OnLayoutChange` の往復でフィードバックループが発生していました。

## Changes
- client
  - `surrounded_text.rs`
    - unsafe COM 変換 (`transmute`) を `IUnknown::try_from` に置換
  - `edit_session.rs`
    - `update_pos` に re-entrant ガードを追加
    - borrow 競合/位置更新失敗時に fail-open 化
  - `text_layout_sink.rs`
    - `OnLayoutChange` 起点の位置更新ループ抑止を追加
    - 抑止期間中の複数コールバックでもガードが維持されるよう修正
  - `text_service.rs`
    - レイアウト通知抑止用状態 (`suppress_layout_change_until`) を追加

## Verification
- [x] LINE で入力時クラッシュが再発しないことを確認
- [x] Cmake-GUI で入力時クラッシュが再発しないことを確認
- [x] Mery でIME ON時の入力開始ハングが再発しないことを確認
- [x] Sublime Text で入力時クラッシュが再発しないことを確認
- [x] Notepad++ で入力時クラッシュが再発しないことを確認

Closes #36